### PR TITLE
Use singular of stars when there's only one star

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -6,7 +6,7 @@
       <h1>{{ vueHasPassedReact ? 'YES' : 'NO' }}</h1>
       <p>
         <small v-if="!vueHasPassedReact">
-          Only {{ reactStars - vueStars | formatNumber }} stars away!
+          Only {{ reactStars - vueStars | formatNumber }} {{ reactStars - vueStars === 1 ? 'star' : 'stars'}} away!
         </small>
       </p>
       <ul>


### PR DESCRIPTION
Fix for when there's only one star difference it now says 'stars'. This should be 'star'