### PR TITLE
Show how many stars Vue ahead of React by

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -9,7 +9,7 @@
         <small v-if="!vueHasPassedReact && !tie" class="away">
           Only {{ reactStars - vueStars | formatNumber }} {{ reactStars - vueStars === 1 ? 'star' : 'stars'}} away!
         </small>
-        <small v-else-if="vueHasPassedReact && !tie" class="away">
+        <small v-else-if="vueHasPassedReact && !tie" class="ahead">
           Ahead by {{ vueStars - reactStars | formatNumber }} {{ vueStars - reactStars === 1 ? 'star' : 'stars'}}!
         </small>
       </p>
@@ -229,7 +229,7 @@ p {
   padding: 0 1em;
 }
 
-.away {
+.away, .ahead {
   display: block;
   margin-bottom: 40px;
 }

--- a/src/App.vue
+++ b/src/App.vue
@@ -9,6 +9,9 @@
         <small v-if="!vueHasPassedReact && !tie" class="away">
           Only {{ reactStars - vueStars | formatNumber }} {{ reactStars - vueStars === 1 ? 'star' : 'stars'}} away!
         </small>
+        <small v-else-if="vueHasPassedReact && !tie" class="away">
+          Ahead by {{ vueStars - reactStars | formatNumber }} {{ vueStars - reactStars === 1 ? 'star' : 'stars'}}!
+        </small>
       </p>
       <ul>
         <li>


### PR DESCRIPTION
Add a paragraph to show how many stars Vue is ahead of React, when that happens. Similar to the "Only x stars away!" that is shown when React is ahead of Vue. As suggested in #10.

![image](https://user-images.githubusercontent.com/1348165/41509799-429d5964-7251-11e8-8b86-5400ce47ba54.png)
